### PR TITLE
enabled cdo-support in genmodel by setting the following properties:

### DIFF
--- a/bundles/org.palladiosimulator.failuremodel.editor/.classpath
+++ b/bundles/org.palladiosimulator.failuremodel.editor/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
 		<attributes>

--- a/bundles/org.palladiosimulator.failuremodel.editor/build.properties
+++ b/bundles/org.palladiosimulator.failuremodel.editor/build.properties
@@ -6,5 +6,5 @@ bin.includes = .,\
                plugin.xml,\
                plugin.properties
 jars.compile.order = .
-source.. = src/
+source.. = src-gen/
 output.. = bin

--- a/bundles/org.palladiosimulator.failuremodel/model/failuremodel.genmodel
+++ b/bundles/org.palladiosimulator.failuremodel/model/failuremodel.genmodel
@@ -2,76 +2,97 @@
 <genmodel:GenModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
     xmlns:genmodel="http://www.eclipse.org/emf/2002/GenModel" modelDirectory="/org.palladiosimulator.failuremodel/src-gen" editDirectory="/org.palladiosimulator.failuremodel.edit/src-gen"
     editorDirectory="/org.palladiosimulator.failuremodel.editor/src-gen" modelPluginID="org.palladiosimulator.failuremodel"
-    modelName="Failuremodel" rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl$Container"
-    testsDirectory="/org.palladiosimulator.failuremodel.tests/src-gen" importerID="org.eclipse.emf.importer.ecore"
-    complianceLevel="5.0" copyrightFields="false" usedGenPackages="../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../de.uka.ipd.sdq.identifier/model/identifier.genmodel#//identifier ../../org.palladiosimulator.pcm/model/pcm.genmodel#//pcm ../../de.uka.ipd.sdq.probfunction/model/ProbabilityFunction.genmodel#//probfunction ../../de.uka.ipd.sdq.stoex/model/stoex.genmodel#//stoex ../../de.uka.ipd.sdq.units/model/Units.genmodel#//units"
+    modelName="Failuremodel" rootExtendsInterface="org.eclipse.emf.cdo.CDOObject"
+    rootExtendsClass="org.eclipse.emf.internal.cdo.CDOObjectImpl" testsDirectory="/org.palladiosimulator.failuremodel.tests/src-gen"
+    importerID="org.eclipse.emf.importer.ecore" featureDelegation="Dynamic" complianceLevel="5.0"
+    copyrightFields="false" usedGenPackages="../../org.eclipse.emf.ecore/model/Ecore.genmodel#//ecore ../../de.uka.ipd.sdq.identifier/model/identifier.genmodel#//identifier ../../org.palladiosimulator.pcm/model/pcm.genmodel#//pcm ../../de.uka.ipd.sdq.probfunction/model/ProbabilityFunction.genmodel#//probfunction ../../de.uka.ipd.sdq.stoex/model/stoex.genmodel#//stoex ../../de.uka.ipd.sdq.units/model/Units.genmodel#//units"
     importOrganizing="true">
   <foreignModel>failuremodel.ecore</foreignModel>
   <genPackages prefix="Failuremodel" basePackage="org.palladiosimulator" disposableProviderFactory="true"
       ecorePackage="failuremodel.ecore#/">
     <nestedGenPackages prefix="Failurescenario" basePackage="org.palladiosimulator.failuremodel"
         disposableProviderFactory="true" ecorePackage="failuremodel.ecore#//failurescenario">
+      <genClasses ecoreClass="failuremodel.ecore#//failurescenario/FailureScenarioRepository">
+        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/FailureScenarioRepository/failurescenarios"/>
+      </genClasses>
       <genClasses ecoreClass="failuremodel.ecore#//failurescenario/FailureScenario">
-        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/FailureScenario/occurences"/>
+        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/FailureScenario/occurrences"/>
+        <genFeatures createChild="false" ecoreFeature="ecore:EAttribute failuremodel.ecore#//failurescenario/FailureScenario/executionEnabled"/>
       </genClasses>
-      <genClasses ecoreClass="failuremodel.ecore#//failurescenario/EntityReference">
+      <genClasses ecoreClass="failuremodel.ecore#//failurescenario/Occurrence">
         <genFeatures notify="false" createChild="false" propertySortChoices="true"
-            ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/EntityReference/referencedEntity"/>
+            ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/Occurrence/failure"/>
+        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/Occurrence/origin"/>
+        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/Occurrence/pointInTime"/>
       </genClasses>
-      <genClasses ecoreClass="failuremodel.ecore#//failurescenario/Occurence">
-        <genFeatures createChild="false" ecoreFeature="ecore:EAttribute failuremodel.ecore#//failurescenario/Occurence/pointOfTime"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failurescenario/Reference"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failurescenario/LinkingResourceReference">
         <genFeatures notify="false" createChild="false" propertySortChoices="true"
-            ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/Occurence/failure"/>
-        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/Occurence/origin"/>
+            ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/LinkingResourceReference/linkingResource"/>
+      </genClasses>
+      <genClasses ecoreClass="failuremodel.ecore#//failurescenario/InternalActionReference">
+        <genFeatures notify="false" createChild="false" propertySortChoices="true"
+            ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/InternalActionReference/internalAction"/>
       </genClasses>
       <genClasses ecoreClass="failuremodel.ecore#//failurescenario/ProcessingResourceReference">
         <genFeatures notify="false" createChild="false" propertySortChoices="true"
             ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/ProcessingResourceReference/processingResource"/>
       </genClasses>
-      <genClasses ecoreClass="failuremodel.ecore#//failurescenario/Reference"/>
-      <genClasses ecoreClass="failuremodel.ecore#//failurescenario/FailureScenarioRepository">
-        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failurescenario/FailureScenarioRepository/failurescenarios"/>
-      </genClasses>
     </nestedGenPackages>
     <nestedGenPackages prefix="Failuretype" basePackage="org.palladiosimulator.failuremodel"
         disposableProviderFactory="true" ecorePackage="failuremodel.ecore#//failuretype">
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/LinkDelayFailure"/>
-      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Content"/>
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/SWPermanentCrashFailure">
-        <genFeatures notify="false" createChild="false" propertySortChoices="true"
-            ecoreFeature="ecore:EReference failuremodel.ecore#//failuretype/SWPermanentCrashFailure/decoratedFailure"/>
-      </genClasses>
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/HWInducedBitFailure"/>
-      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/SWFailure">
-        <genOperations ecoreOperation="failuremodel.ecore#//failuretype/SWFailure/getSupportedElementTypes"/>
-      </genClasses>
-      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Permanent"/>
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/SWCrashFailure"/>
-      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/LinkFailure">
-        <genOperations ecoreOperation="failuremodel.ecore#//failuretype/LinkFailure/getSupportedElementTypes"/>
-      </genClasses>
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/SWTransientCrashFailure">
-        <genFeatures notify="false" createChild="false" propertySortChoices="true"
-            ecoreFeature="ecore:EReference failuremodel.ecore#//failuretype/SWTransientCrashFailure/decoratedFailure"/>
-      </genClasses>
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/LinkResponseFailure"/>
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/SWLongCalcFailure"/>
-      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Transient"/>
-      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Crash"/>
-      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Timing"/>
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/SWInducedBitFailure"/>
-      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/HWFailure">
-        <genOperations ecoreOperation="failuremodel.ecore#//failuretype/HWFailure/getSupportedElementTypes"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/FailureTypeRepository">
+        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failuretype/FailureTypeRepository/failuretypes"/>
       </genClasses>
       <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Failure">
-        <genOperations ecoreOperation="failuremodel.ecore#//failuretype/Failure/getSupportedElementTypes"/>
+        <genOperations ecoreOperation="failuremodel.ecore#//failuretype/Failure/getSupportedElementType"/>
       </genClasses>
-      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Byzantine"/>
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/HWLowerProcessingRateFailure"/>
-      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Mode"/>
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/LinkCrashFailure"/>
-      <genClasses ecoreClass="failuremodel.ecore#//failuretype/HWNAFailure"/>
+      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/SWFailure">
+        <genOperations ecoreOperation="failuremodel.ecore#//failuretype/SWFailure/getSupportedElementType"/>
+      </genClasses>
+      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/HWFailure">
+        <genOperations ecoreOperation="failuremodel.ecore#//failuretype/HWFailure/getSupportedElementType"/>
+      </genClasses>
+      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/LinkFailure">
+        <genOperations ecoreOperation="failuremodel.ecore#//failuretype/LinkFailure/getSupportedElementType"/>
+      </genClasses>
       <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Domain"/>
+      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Content">
+        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failuretype/Content/degreeOfCorruption"/>
+      </genClasses>
+      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Timing">
+        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failuretype/Timing/delay"/>
+        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failuretype/Timing/scalingFactor"/>
+      </genClasses>
+      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Crash"/>
+      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Mode"/>
+      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Transient">
+        <genTypeParameters ecoreTypeParameter="failuremodel.ecore#//failuretype/Transient/Failuretype"/>
+        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failuretype/Transient/duration"/>
+        <genFeatures notify="false" createChild="false" propertySortChoices="true"
+            ecoreFeature="ecore:EReference failuremodel.ecore#//failuretype/Transient/decoratedFailure"/>
+      </genClasses>
+      <genClasses image="false" ecoreClass="failuremodel.ecore#//failuretype/Byzantine">
+        <genTypeParameters ecoreTypeParameter="failuremodel.ecore#//failuretype/Byzantine/Failuretype"/>
+        <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference failuremodel.ecore#//failuretype/Byzantine/probabilityOfOccurrence"/>
+        <genFeatures notify="false" createChild="false" propertySortChoices="true"
+            ecoreFeature="ecore:EReference failuremodel.ecore#//failuretype/Byzantine/decoratedFailure"/>
+      </genClasses>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/SWCrashFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/SWTimingFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/SWContentFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/SWTransientFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/SWByzantineFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/HWCrashFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/HWTimingFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/HWContentFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/HWTransientFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/HWByzantineFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/LinkCrashFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/LinkTimingFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/LinkContentFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/LinkTransientFailure"/>
+      <genClasses ecoreClass="failuremodel.ecore#//failuretype/LinkByzantineFailure"/>
     </nestedGenPackages>
   </genPackages>
 </genmodel:GenModel>


### PR DESCRIPTION
Model.Feature Delegate:Dynamic; Model Class Defaults . Root Extends Class : org.eclipse.emf.internal.cdo.CDOObjectImpl; Root Extends Interface: org.eclipse.emf.cdo.CDOObject

The changes were required to enable CDO support for failurescenario model.
Otherwise EMF copier class failed to copy the model during CopyPartitionJob